### PR TITLE
Revamped Upcoming Tournaments Section, fixed tournament day bug

### DIFF
--- a/tournamentupcoming.php
+++ b/tournamentupcoming.php
@@ -4,39 +4,20 @@ require_once("checksession.php"); //Check to make sure user is logged in and has
 require_once("functions.php");
 
 $userID = $_SESSION['userData']['userID'];
+$studentID = getStudentID($mysqlConn,$userID);
 $fallRosterDate = strval(getCurrentSOYear()-1)."-08-01";
 $date = date('Y-m-d', time());
 //fallRosterDate should be changed to a part of the table that indicated that this is a roster (not a tournament)
-$query = "SELECT * FROM `student` INNER JOIN `teammate` ON `student`.`studentID`=`teammate`.`studentID` INNER JOIN `team` ON `teammate`.`teamID` = `team`.`teamID` INNER JOIN `tournament` ON `team`.`tournamentID` = `tournament`.`tournamentID` WHERE `userID` = $userID and `dateTournament` > '$date' and `dateTournament` != '$fallRosterDate'";
+$query = "SELECT * FROM `student` INNER JOIN `teammate` ON `student`.`studentID`=`teammate`.`studentID` INNER JOIN `team` ON `teammate`.`teamID` = `team`.`teamID` INNER JOIN `tournament` ON `team`.`tournamentID` = `tournament`.`tournamentID` WHERE `userID` = $userID and `dateTournament` >= '$date' and `dateTournament` != '$fallRosterDate'";
 $result = $mysqlConn->query($query) or print("\n<br />Warning: query failed:$query. " . $mysqlConn->error. ". At file:". __FILE__ ." by " . $_SERVER['REMOTE_ADDR'] .".");
 $tournaments = '';
 
 while ($row = $result->fetch_assoc()):
+    {
     $tournaments.="<div id=\"".$row['tournamentName']."\">";
-    $tournaments.="<h3><a href=\"#tournament-view-".$row['tournamentID']."\">".$row['tournamentName']." - ".$row['teamName']." Team</a></h3>";
+    $tournaments.="<a href=\"#tournament-view-".$row['tournamentID']."\"><h3>".$row['tournamentName']." - ".$row['teamName']." Team</h3></a>";
     $tournamentID = $row['tournamentID'];
-    $tournamentQuery = "SELECT `student`.`studentID`, `tournamentevent`.`tournamenteventID`, `teamID`,`userID`,`event`.`eventID`, `event`.`event` FROM `teammateplace` INNER JOIN `student` on `teammateplace`.`studentID` = `student`.`studentID` INNER JOIN `tournamentevent` on `teammateplace`.`tournamenteventID` = `tournamentevent`.`tournamenteventID` inner join `event` on `tournamentevent`.`eventID` = `event`.`eventID` where `tournamentID` = $tournamentID and `userID` = $userID";
-    // $tournaments.=$tournamentQuery;
-    $tournamentResult = $mysqlConn->query($tournamentQuery) or print("\n<br />Warning: query failed:$tournamentQuery. " . $mysqlConn->error. ". At file:". __FILE__ ." by " . $_SERVER['REMOTE_ADDR'] .".");
-    if($tournamentResult->num_rows > 0){
-        $tournaments.="Your events and partners:<br><ul>";
-        while ($row = $tournamentResult->fetch_assoc()):
-            $tournamenteventID = $row['tournamenteventID'];
-            $teamID = $row['teamID'];
-            $studentID = getStudentID($mysqlConn, $userID);
-            $tournaments.="<li>".$row['event'];
-            $partnerQuery = "SELECT * FROM `teammateplace` INNER JOIN `student` ON `teammateplace`.`studentID` = `student`.`studentID` WHERE `tournamenteventID` = $tournamenteventID and `teamID` = $teamID and `student`.`studentID` != $studentID";
-            $partnerResult = $mysqlConn->query($partnerQuery) or print("\n<br />Warning: query failed:$partnerQuery. " . $mysqlConn->error. ". At file:". __FILE__ ." by " . $_SERVER['REMOTE_ADDR'] .".");
-            if($partnerResult){
-                $tournaments.="<ul>";
-                while ($row = $partnerResult->fetch_assoc()):
-                    $tournaments.="<li>".$row['first']." ".$row['last']." ".$row['email']."</li>";
-                endwhile;
-                $tournaments.="</ul>";
-            }
-            $tournaments.="</li>";
-        endwhile;
-        $tournaments.="</ul>";
+    $tournaments.=studentTournamentSchedule($mysqlConn, $tournamentID, $studentID);
     }
     $tournaments.="</div>";
 endwhile;

--- a/tournamentview.php
+++ b/tournamentview.php
@@ -1,6 +1,7 @@
 <?php
 require_once  ("../connectsodb.php");
 require_once  ("checksession.php"); //Check to make sure user is logged in and has privileges
+require_once("functions.php");
 
 userCheckPrivilege(1);
 //text output
@@ -18,6 +19,8 @@ if(empty($result))
 
 $row = $result->fetch_assoc();
 $numberTeams = $row["numberTeams"];
+$userID = $_SESSION['userData']['userID'];
+$studentID = getStudentID($mysqlConn,$userID);
 
 //Get number of teams created
 $query = "SELECT * FROM `team` WHERE `tournamentID` = $tournamentID";
@@ -126,8 +129,17 @@ $amountOfCreatedTeams = $resultTeams->num_rows;
 				$output .=" <input class='button fa' type='button' onclick='window.location.hash=\"tournament-teamassign-".$rowTeam['teamID']."\"' value='&#xf06d; View Events' /></p>";
 			}
 		endwhile;
+		$schedule.=studentTournamentSchedule($mysqlConn, $tournamentID, $studentID);
+		if($schedule != -1){
+			$output .="<h3>My Schedule (Team ".getStudentTeam($mysqlConn, $tournamentID, $studentID).")</h3>";
+			$output.=$schedule;
+		}
+		else{
+			$output .= "You have not been assigned to events at this tournament.<br><br>";
+		}
 	}
 	$output .="</div>";
+
 	$output .= "<input class='button fa' type='button' onclick=\"window.location='#tournaments'\" value='&#xf0a8; Return' />";
 echo $output;
 ?>


### PR DESCRIPTION
I made sure the tournament shows up under upcoming tournaments the day of the competition. Here are screenshots of how the Upcoming Tournaments section looks given these changes. I also added the same table under the tournaments page for tournaments the student is assigned to.

Note: I realized that EST isn't technically accurate in case the tournament is still during DST. I changed it to ET instead.

![image](https://user-images.githubusercontent.com/64321319/141161809-108841b5-eeef-4cc3-be6b-3520fcb9b070.png)
![image](https://user-images.githubusercontent.com/64321319/141161833-b3499490-b2ce-418e-85d9-7ccf1c4e3dd4.png)
![image](https://user-images.githubusercontent.com/64321319/141161843-afc43cdf-d749-4cfd-81e2-54e51187f8e9.png)
