### PR TITLE
Tournament schedule lock

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -1162,6 +1162,54 @@ function tournamentEventTimeChange(myID)
 	});
 }
 
+function tournamentTeamLock(myID)
+{
+	if(confirm("Lock team assignments?"))
+	{
+		tournamentTeamLockToggle(myID);
+	}
+}
+function tournamentTeamUnLock(myID)
+{
+	if(confirm("Unlock team assignments?"))
+	{
+		tournamentTeamLockToggle(myID);
+	}
+}
+
+function tournamentTeamLockToggle(myID) {
+	var request = $.ajax({
+		url: "tournamentschedulelock.php",
+		cache: false,
+		method: "POST",
+		data: {myID:myID},
+		dataType: "html"
+	});
+	request.done(function( html ) {
+		$(".text-success").remove();
+		if(html=="1")
+		{
+			//locked
+			$("#lockBtn").replaceWith("<a id='lockBtn' class='btn btn-secondary' role='button' href='javascript:tournamentTeamUnLock("+myID+")'><span class='bi bi-unlock'></span> Unlock</a>"); 
+		}
+		else if(html=="0")
+		{
+			//unlocked
+			$("#lockBtn").replaceWith("<a id='lockBtn' class='btn btn-secondary' role='button' href='javascript:tournamentTeamLock("+myID+")'><span class='bi bi-lock'></span> Lock</a>"); 
+		}
+		else
+		{
+			$("#lockBtn").before("<div class='text-danger'>Error:"+html+"</div");
+		}
+	});
+
+	request.fail(function( jqXHR, textStatus ) {
+		$(".text-success").remove();
+		$("#tournament-teamassign-" + myID).before("<div class='text-danger'>Removal Error:"+textStatus+"</div");
+	});
+}
+
+
 function toggleAdd()
 {
 	$('#addTo').toggle();

--- a/tournamentschedulelock
+++ b/tournamentschedulelock
@@ -1,0 +1,31 @@
+<?php
+require_once("php/functions.php");
+userCheckPrivilege(4);
+
+$teamID = intval($_REQUEST['myID']);
+$query = "SELECT `team`.`locked` from `team` WHERE `team`.`teamID` = $teamID";
+$result = $mysqlConn->query($query) or error_log("\n<br />Warning: query failed:$query. " . $mysqlConn->error. ". At file:". __FILE__ ." by " . $_SERVER['REMOTE_ADDR'] .".");
+
+if(empty($result))
+{
+	echo "Query Tournament Schedule Lock Failed.";
+	exit("2");
+}
+
+$row = $result->fetch_assoc();
+// the team is locked
+if($row['locked'] == 1)
+{
+    // change locked to 0 - unlocked
+    $query = "UPDATE `team` SET `locked` = '0' WHERE `team`.`teamID` = $teamID";
+    $result = $mysqlConn->query($query) or error_log("\n<br />Warning: query failed:$query. " . $mysqlConn->error. ". At file:". __FILE__ ." by " . $_SERVER['REMOTE_ADDR'] .".");
+    exit("0"); // unlocked
+}
+// the team is unlocked
+else if($row['locked'] == 0) {
+    // change locked to 1 - locked
+    $query = "UPDATE `team` SET `locked` = '1' WHERE `team`.`teamID` = $teamID";
+    $result = $mysqlConn->query($query) or error_log("\n<br />Warning: query failed:$query. " . $mysqlConn->error. ". At file:". __FILE__ ." by " . $_SERVER['REMOTE_ADDR'] .".");
+    exit("1"); // locked
+}
+?>


### PR DESCRIPTION
Added a button to tournamentteamassign.php that allows schedules to be locked, preventing officers from clicking the checkboxes once they are finalized (user privilege for locking schedules is currently set to 4 so that I could test it, but can be changed to 5)

Added a new variable "locked" to "tournament" with a default value of 0 (unlocked), see attached image

![image](https://github.com/wolfe3d/sodata/assets/106262582/f2e2252c-5fc7-4091-9ad7-ed27033d9adb)

