### PR TITLE
Fix teamcopy bug

### DIFF
--- a/teamcopylist.php
+++ b/teamcopylist.php
@@ -26,6 +26,6 @@ function getTeamStudents($teamID)
 	}
 }
 
-$teamID = intval($_POST['team']);
+$teamID = intval($_POST['myID']);
 echo json_encode(getTeamStudents($teamID));
 ?>


### PR DESCRIPTION
Copying teams wasn't working during officer meetings. Changed 'team' index to 'myID' for the team number.
Fixed error: Notice: Undefined index: team in C:\UwAmp\www\sodata\teamcopylist.php on line 29